### PR TITLE
Download all versions of ruby from servers

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -181,21 +181,11 @@ get_download_url() {
   local ruby_version=$(get_ruby_version $version)
 
   if [ "${ruby_type}" = "ruby" ]; then
-    local ruby_base_version=$(get_ruby_base_version $ruby_version)
-    echo "http://cache.ruby-lang.org/pub/ruby/${ruby_base_version}/ruby-${ruby_version}.tar.gz"
+    echo "http://cache.ruby-lang.org/pub/ruby/ruby-${ruby_version}.tar.gz"
   elif [ "${ruby_type}" = "jruby" ]; then
     echo "https://s3.amazonaws.com/jruby.org/downloads/${ruby_version}/jruby-bin-${ruby_version}.tar.gz"
   fi
 }
-
-
-get_ruby_base_version() {
-  IFS='-' read -a version_info <<< "$1"
-  IFS='.' read -a version <<< "${version_info[0]}"
-
-  echo "${version[0]}.${version[1]}"
-}
-
 
 get_ruby_version() {
   IFS='-' read -a version_info <<< "$1"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ruby_versions=$(
-  curl --silent -H "Content-Type:text/html" "http://cache.ruby-lang.org/pub/ruby/" \
+  curl --silent --compressed "http://cache.ruby-lang.org/pub/ruby/" \
     | sed -n -E 's/^.*"(ruby-)(.*).tar.gz".*$/\2/p' \
     | sort \
     | uniq

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,23 +1,17 @@
 #!/usr/bin/env bash
 
-versions_list=(
-  jruby-9.0.4.0
-  1.9.3-p551
-  2.1.4
-  2.1.5
-  2.1.6
-  2.1.7
-  2.2.0
-  2.2.1
-  2.2.2
-  2.2.3
-  2.3.0
-  2.3.1
+ruby_versions=$(
+  curl --silent "http://cache.ruby-lang.org/pub/ruby/" \
+    | sed -n -E 's/^.*"(ruby-)(.*).tar.gz".*$/\2/p' \
+    | sort \
+    | uniq
 )
 
-versions=""
+jruby_versions=(
+  jruby-9.0.4.0
+)
 
-for version in "${versions_list[@]}"
+for version in "${ruby_versions[@]} ${jruby_versions[@]}"
 do
   versions="${versions} ${version}"
 done

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,16 +1,27 @@
 #!/usr/bin/env bash
 
+RUBY_VERSIONS_URL=https://raw.githubusercontent.com/postmodern/ruby-versions/master/ruby/versions.txt
+JRUBY_VERSIONS_URL=https://raw.githubusercontent.com/postmodern/ruby-versions/master/jruby/versions.txt
+
+function get_versions() {
+  curl --silent $1
+}
+
 ruby_versions=$(
-  curl --silent --compressed "http://cache.ruby-lang.org/pub/ruby/" \
-    | sed -n -E 's/^.*"(ruby-)(.*).tar.gz".*$/\2/p' \
-    | uniq
+  get_versions $RUBY_VERSIONS_URL
+)
+jruby_versions=$(
+  get_versions $JRUBY_VERSIONS_URL
 )
 
-jruby_versions=(
-  jruby-9.0.4.0
-)
+versions=""
 
-for version in "${ruby_versions[@]} ${jruby_versions[@]}"
+for version in ${jruby_versions[@]}
+do
+  versions="${versions} jruby-${version}"
+done
+
+for version in ${ruby_versions[@]}
 do
   versions="${versions} ${version}"
 done

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+LC_CTYPE=C
+LANG=C
+
 ruby_versions=$(
   curl --silent "http://cache.ruby-lang.org/pub/ruby/" \
     | sed -n -E 's/^.*"(ruby-)(.*).tar.gz".*$/\2/p' \

--- a/bin/list-all
+++ b/bin/list-all
@@ -3,7 +3,6 @@
 ruby_versions=$(
   curl --silent --compressed "http://cache.ruby-lang.org/pub/ruby/" \
     | sed -n -E 's/^.*"(ruby-)(.*).tar.gz".*$/\2/p' \
-    | sort \
     | uniq
 )
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 
-LC_CTYPE=C
-LANG=C
-
 ruby_versions=$(
-  curl --silent "http://cache.ruby-lang.org/pub/ruby/" \
+  curl --silent -H "Content-Type:text/html" "http://cache.ruby-lang.org/pub/ruby/" \
     | sed -n -E 's/^.*"(ruby-)(.*).tar.gz".*$/\2/p' \
     | sort \
     | uniq


### PR DESCRIPTION
I've notices that I can install `2.4.0-preview3` but it's not on the list. Now list is downloaded directly from server. JRuby is an exception, is still a static list. 