### PR TITLE
include current Ruby install path in PATH

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -8,3 +8,5 @@ if [ "$RUBYLIB" = "" ]; then
 else
   export RUBYLIB="$ruby_plugin_dir/rubygems-plugin:$RUBYLIB"
 fi
+
+export PATH=$install_path/bin:$PATH


### PR DESCRIPTION
### Summary
[This issue comment](https://github.com/asdf-vm/asdf/issues/64#issuecomment-261809489) perfectly describes the issue.

### Intended effect
As per the linked comment, this change implements the suggested fix to prepend the install path to the `PATH` environment variable.

### How I tested
I ran into this issue when migrating from `rbenv` to `asdf`. My Ruby linter stopped working in Sublime Text.

Before I made the change, this is the debug trace from Sublime Text when trying to execute the linter, in this case `rubocop`:

```
SublimeLinter: ENV['GEM_HOME'] = 'None' 
Package Control: No updated packages
SublimeLinter: rubocop version query: /Users/ed/.asdf/shims/ruby -S rubocop --version 
SublimeLinter: rubocop version: 2.3.1 
SublimeLinter: rubocop: (>= 0.34.0) satisfied by 2.3.1 
SublimeLinter: rubocop activated: ['/Users/ed/.asdf/shims/ruby'] 
SublimeLinter: rubocop: account_comp.rb ['ruby', '-S', 'rubocop', '--format', 'emacs', '--force-exclusion', '--stdin', '/Users/ed/Code/some-app/some-ruby-file.rb'] 
SublimeLinter: rubocop output:
/Users/ed/.asdf/installs/ruby/2.3.0/bin/ruby: no Ruby script found in input (LoadError)
```

After making the change, when I restart Sublime Text the `rubocop` linter is invoked as expected.

### Comments

My understanding of `asdf` is limited so if there is a better way of doing this please let me know. 

I cannot claim credit for this change but there doesn't seem to be any existing pull request from @nicholasjhenry.

Apologies if this is a duplicate.