### PR TITLE
allow to apply custom patches during install (fixes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ When installing Ruby using `asdf install`, you can pass custom configure options
 * `RUBY_CONFIGURE_OPTIONS` - use only your configure options
 * `RUBY_EXTRA_CONFIGURE_OPTIONS` - append these configure options along with ones that this plugin already uses
 
+You may also apply custom patches before building with `RUBY_APPLY_PATCHES`, e.g.
+
+```
+RUBY_APPLY_PATCHES=$'dir/1.patch\n2.patch\nhttp://example.com/3.patch' asdf install ruby 2.4.1
+RUBY_APPLY_PATCHES=$(curl -s https://raw.githubusercontent.com/rvm/rvm/master/patchsets/ruby/2.1.1/railsexpress) asdf install ruby 2.1.1
+```
+
 ## Default gems
 
 asdf-ruby can automatically install a set of default gems right after

--- a/bin/install
+++ b/bin/install
@@ -37,7 +37,7 @@ install_ruby() {
       echo "WARNING: Might use OS-provided pkgs for the following: $ASDF_PKG_MISSING"
     fi
 
-    apply_custom_patches $start_dir || exit 1
+    apply_custom_patches "$start_dir" || exit 1
 
     local configure_options="$(construct_configure_options $install_path)"
     # set in os_based_configure_options
@@ -81,9 +81,11 @@ get_absolute_path() {
   local rel_dir=$(dirname "$rel_path")
   local rel_base=$(basename "$rel_path")
 
-  echo $(
-    cd "$start_dir"
-    cd "$rel_dir" 2>/dev/null && echo "$(pwd)/$rel_base" || echo "$rel_path"
+  (
+    cd "$start_dir" \
+      && cd "$rel_dir" 2>/dev/null \
+      && echo "$(pwd)/$rel_base" \
+      || echo "$rel_path"
   )
 }
 

--- a/bin/install
+++ b/bin/install
@@ -5,6 +5,7 @@ install_ruby() {
   local version=$2
   local install_path=$3
   local ruby_type=$(get_ruby_type $version)
+  local start_dir=$(pwd)
 
   if [ "$TMPDIR" = "" ]; then
     local tmp_download_dir=$(mktemp -d -t ruby_build_XXXXXX)
@@ -36,6 +37,8 @@ install_ruby() {
       echo "WARNING: Might use OS-provided pkgs for the following: $ASDF_PKG_MISSING"
     fi
 
+    apply_custom_patches $start_dir || exit 1
+
     local configure_options="$(construct_configure_options $install_path)"
     # set in os_based_configure_options
     # we unset it here because echo-ing changes the return value of the function
@@ -49,6 +52,40 @@ install_ruby() {
   )
 }
 
+apply_custom_patches() {
+  local start_dir=$1
+  while read -r line; do
+    if [ "$line" = "" ]; then
+      continue
+    fi
+    # define earlier, so that the exit 1 shorthand below works
+    local content
+    if [[ "$line" =~ ^[Hh][Tt][Tt][Pp][Ss]?:// ]]; then
+      echo "Applying patch from URL: $line"
+      content=$(curl -s "$line") || exit 1
+    else
+      local abs_path=$(get_absolute_path "$start_dir" "$line")
+      echo "Applying local patch: $abs_path"
+      content=$(<"$abs_path") || exit 1
+    fi
+
+    local striplevel=0
+    grep -q '^diff --git a/' <<< "$content" && striplevel=1
+    patch -p$striplevel --force <<< "$content" || exit 1
+  done <<< "$RUBY_APPLY_PATCHES"
+}
+
+get_absolute_path() {
+  local start_dir=$1
+  local rel_path=$2
+  local rel_dir=$(dirname "$rel_path")
+  local rel_base=$(basename "$rel_path")
+
+  echo $(
+    cd "$start_dir"
+    cd "$rel_dir" 2>/dev/null && echo "$(pwd)/$rel_base" || echo "$rel_path"
+  )
+}
 
 construct_configure_options() {
   local install_path=$1


### PR DESCRIPTION
My preliminary testing is done, but I will give it a more thorough spin tomorrow. In the meantime, please take a look. If you see a better way to resolve relative paths, that'd be nice. The patch introduces a couple of new dependencies: `grep`, `patch` and it requires a Bash 3+ something, due to the regex operator.

Cheers
Stefan