### PR TITLE
use available CPU cores when compiling (fixes #42)

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -44,7 +44,7 @@ install_ruby() {
     echo "Building with options: $configure_options"
 
     ./configure $configure_options || exit 1
-    make || exit 1
+    make -j"${ASDF_CONCURRENCY:-1}" || exit 1
     make install || exit 1
   )
 }


### PR DESCRIPTION
Good hint about `$ASDF_CONCURRENCY`, it makes this much simpler than anticipated!