### PR TITLE
Update doc: use `mv -T` to move rbenv rubies to asdf rubies

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ directory:
 #### rbenv
 
     mkdir ~/.asdf/installs/
-    mv ~/.rbenv/versions ~/.asdf/installs/ruby/
+    mv -T ~/.rbenv/versions ~/.asdf/installs/ruby/
 
 #### chruby
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ directory:
 #### rbenv
 
     mkdir ~/.asdf/installs/
-    mv -T ~/.rbenv/versions ~/.asdf/installs/ruby/
+    mv ~/.rbenv/versions/* ~/.asdf/installs/ruby/
 
 #### chruby
 


### PR DESCRIPTION
Using `mv -T` allows `~/.rbenv/versions` to rename to `~/.asdf/installs/ruby` instead of ending up with `~/.asdf/installs/ruby/versions` (default behavior of `mv` without `-T`)