### PR TITLE
Use ruby-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,7 @@ asdf plugin-add ruby https://github.com/asdf-vm/asdf-ruby.git
 
 Check [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install & manage versions of Ruby.
 
-When installing Ruby using `asdf install`, you can pass custom configure options with the following env vars:
-
-* `RUBY_CONFIGURE_OPTIONS` - use only your configure options
-* `RUBY_EXTRA_CONFIGURE_OPTIONS` - append these configure options along with ones that this plugin already uses
+When installing Ruby using `asdf install`, you can pass custom configure options with the [env vars supported by ruby-build](https://github.com/rbenv/ruby-build#custom-build-configuration).
 
 You may also apply custom patches before building with `RUBY_APPLY_PATCHES`, e.g.
 

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 current_script_path=${BASH_SOURCE[0]}
-ruby_plugin_dir=$(dirname $(dirname $current_script_path))
+ruby_plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
 if [ "$RUBYLIB" = "" ]; then
   export RUBYLIB="$ruby_plugin_dir/rubygems-plugin"

--- a/bin/get-version-from-legacy-file
+++ b/bin/get-version-from-legacy-file
@@ -5,9 +5,9 @@ get_legacy_version() {
   ruby_version_file="$current_directory/.ruby-version"
 
   # Get version from .ruby-version file. .ruby-version is used by rbenv and now rvm.
-  if [ -f $ruby_version_file ]; then
-    cat $ruby_version_file
+  if [ -f "$ruby_version_file" ]; then
+    cat "$ruby_version_file"
   fi
 }
 
-get_legacy_version $1
+get_legacy_version "$1"

--- a/bin/get-version-from-legacy-file
+++ b/bin/get-version-from-legacy-file
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 get_legacy_version() {
-    current_directory=$1
-    ruby_version_file="$current_directory/.ruby-version"
+  current_directory=$1
+  ruby_version_file="$current_directory/.ruby-version"
 
-    # Get version from .ruby-version file. .ruby-version is used by rbenv and now rvm.
-    if [ -f $ruby_version_file ]; then
-        cat $ruby_version_file
-    fi
+  # Get version from .ruby-version file. .ruby-version is used by rbenv and now rvm.
+  if [ -f $ruby_version_file ]; then
+    cat $ruby_version_file
+  fi
 }
 
 get_legacy_version $1

--- a/bin/install
+++ b/bin/install
@@ -51,21 +51,21 @@ install_default_gems() {
   local default_gems="${HOME}/.default-gems"
   local gem_bin="${ASDF_INSTALL_PATH}/bin/gem"
 
-  if [ ! -f $default_gems ]; then return; fi
+  if [ ! -f "$default_gems" ]; then return; fi
 
   echo ""
 
-  for name in $(cat $default_gems); do
+  while read -r name; do
     echo -n "Installing ${name} gem... "
 
-    if $gem_bin install $name > /dev/null 2>&1; then
+    if $gem_bin install "$name" > /dev/null 2>&1; then
       echo "SUCCESS"
     else
       echo "FAIL"
     fi
-  done
+  done <<< "$(cat "$default_gems")"
 }
 
 ensure_ruby_build_available
-install_ruby $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
+install_ruby "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
 install_default_gems

--- a/bin/install
+++ b/bin/install
@@ -24,7 +24,7 @@ fetch_patches() {
     if [ "$line" = "" ]; then continue; fi
     if [[ "$line" =~ ^[Hh][Tt][Tt][Pp][Ss]?:// ]]; then
       >&2 echo "Using patch from URL: $line"
-      curl -s "$line" || exit 1
+      curl -fSs "$line" || exit 1
     else
       local abs_path=$(get_absolute_path "$line")
       >&2 echo "Using local patch: $abs_path"

--- a/bin/install
+++ b/bin/install
@@ -1,82 +1,40 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
+# shellcheck source=../lib/utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/utils.sh"
+
 install_ruby() {
   local install_type=$1
   local version=$2
   local install_path=$3
-  local ruby_type=$(get_ruby_type $version)
-  local start_dir=$(pwd)
 
-  if [ "$TMPDIR" = "" ]; then
-    local tmp_download_dir=$(mktemp -d -t ruby_build_XXXXXX)
-  else
-    local tmp_download_dir=$TMPDIR
+  if [ "$install_type" != "version" ]; then
+    echoerr "Cannot install specific ref from source, sorry."
+    echoerr "For a list of available versions, see \`asdf list-all ruby\`"
+    exit 1
   fi
 
-  # path to the tar file
-  local source_path=$(get_download_file_path $install_type $version $tmp_download_dir)
-
-  download_source $install_type $version $source_path
-
-  # running this in a subshell
-  # because we don't want to disturb current working dir
-  (
-    cd $(dirname $source_path)
-    if [ "${ruby_type}" = "jruby" ]; then
-      tar zxf $source_path -C $(dirname $install_path) || exit 1
-      exit 0
-    else
-      tar zxf $source_path || exit 1
-    fi
-
-    # we use untar path because the extracted dir maybe diff
-    # ideally should be using tar with --strip-components 1
-    cd $(untar_path $install_type $version $tmp_download_dir)
-
-    if [ "$ASDF_PKG_MISSING" != "" ]; then
-      echo "WARNING: Might use OS-provided pkgs for the following: $ASDF_PKG_MISSING"
-    fi
-
-    apply_custom_patches "$start_dir" || exit 1
-
-    local configure_options="$(construct_configure_options $install_path)"
-    # set in os_based_configure_options
-    # we unset it here because echo-ing changes the return value of the function
-    unset ASDF_PKG_MISSING
-
-    echo "Building with options: $configure_options"
-
-    ./configure $configure_options || exit 1
-    make -j"${ASDF_CONCURRENCY:-1}" || exit 1
-    make install || exit 1
-  )
+  fetch_patches | ruby-build --patch "$version" "$install_path" ${RUBY_BUILD_OPTS:-}
 }
 
-apply_custom_patches() {
-  local start_dir=$1
+fetch_patches() {
   while read -r line; do
-    if [ "$line" = "" ]; then
-      continue
-    fi
-    # define earlier, so that the exit 1 shorthand below works
-    local content
+    if [ "$line" = "" ]; then continue; fi
     if [[ "$line" =~ ^[Hh][Tt][Tt][Pp][Ss]?:// ]]; then
-      echo "Applying patch from URL: $line"
-      content=$(curl -s "$line") || exit 1
+      >&2 echo "Using patch from URL: $line"
+      curl -s "$line" || exit 1
     else
-      local abs_path=$(get_absolute_path "$start_dir" "$line")
-      echo "Applying local patch: $abs_path"
-      content=$(<"$abs_path") || exit 1
+      local abs_path=$(get_absolute_path "$line")
+      >&2 echo "Using local patch: $abs_path"
+      cat "$abs_path" || exit 1
     fi
-
-    local striplevel=0
-    grep -q '^diff --git a/' <<< "$content" && striplevel=1
-    patch -p$striplevel --force <<< "$content" || exit 1
-  done <<< "$RUBY_APPLY_PATCHES"
+  done <<< "${RUBY_APPLY_PATCHES:-}"
 }
 
 get_absolute_path() {
-  local start_dir=$1
+  local start_dir=$(pwd)
   local rel_path=$2
   local rel_dir=$(dirname "$rel_path")
   local rel_base=$(basename "$rel_path")
@@ -88,174 +46,6 @@ get_absolute_path() {
       || echo "$rel_path"
   )
 }
-
-construct_configure_options() {
-  local install_path=$1
-
-  if [ "$RUBY_CONFIGURE_OPTIONS" = "" ]; then
-    local configure_options="$(os_based_configure_options) --prefix=$install_path"
-
-    if [ "$RUBY_EXTRA_CONFIGURE_OPTIONS" != "" ]; then
-      configure_options="$configure_options $RUBY_EXTRA_CONFIGURE_OPTIONS"
-    fi
-  else
-    local configure_options="$RUBY_CONFIGURE_OPTIONS --prefix=$install_path"
-  fi
-
-  echo "$configure_options"
-}
-
-
-homebrew_package_path() {
-  local package_name=$1
-
-  if [ "$(brew ls --versions $package_name)" = "" ]; then
-    echo ""
-  else
-    echo "$(brew --prefix $package_name)"
-  fi
-}
-
-
-exit_if_homebrew_not_installed() {
-  if [ "$(brew --version 2>/dev/null)" = "" ]; then
-    echo "ERROR: Please install homebrew for OSX"
-    exit 1
-  fi
-}
-
-
-os_based_configure_options() {
-  local operating_system=$(uname -a)
-  local configure_options=""
-
-  if [[ "$operating_system" =~ "Darwin" ]]; then
-
-    exit_if_homebrew_not_installed
-
-    local openssl_path=$(homebrew_package_path openssl)
-    local libyaml_path=$(homebrew_package_path libyaml)
-    local readline_path=$(homebrew_package_path readline)
-  else
-    local openssl_path=/usr
-    local libyaml_path=/usr
-  fi
-
-  if [ "$openssl_path" = "" ]; then
-    export ASDF_PKG_MISSING="openssl"
-  else
-    configure_options="--with-openssl-dir=$openssl_path"
-  fi
-
-  if [ "$libyaml_path" = "" ]; then
-    export ASDF_PKG_MISSING="$ASDF_PKG_MISSING libyaml"
-  else
-    configure_options="$configure_options --with-libyaml-dir=$libyaml_path"
-  fi
-
-  if [ "$readline_path" != "" ]; then
-    configure_options="$configure_options --with-readline-dir=$readline_path"
-  fi
-
-  configure_options="$configure_options --enable-shared --disable-install-doc"
-  echo $configure_options
-}
-
-
-download_source() {
-  local install_type=$1
-  local version=$2
-  local download_path=$3
-  local download_url=$(get_download_url $install_type $version)
-
-  if [ -f $download_path ]; then
-    rm $download_path
-  fi
-
-  curl -Lo $download_path $download_url
-}
-
-
-get_download_file_path() {
-  local install_type=$1
-  local version=$2
-  local tmp_download_dir=$3
-
-  local ruby_type=$(get_ruby_type $version)
-  local ruby_version=$(get_ruby_version $version)
-
-  if [ "${ruby_type}" = "ruby" ]; then
-    local pkg_name="ruby-${ruby_version}.tar.gz"
-  elif [ "${ruby_type}" = "jruby" ]; then
-    local pkg_name="jruby-bin-${ruby_version}.tar.gz"
-  fi
-
-  echo "$tmp_download_dir/$pkg_name"
-}
-
-
-untar_path() {
-  local install_type=$1
-  local version=$2
-  local tmp_download_dir=$3
-
-  local ruby_type=$(get_ruby_type $version)
-  local ruby_version=$(get_ruby_version $version)
-
-  if [ "${ruby_type}" = "ruby" ]; then
-    local dir_name="ruby-${ruby_version}"
-  elif [ "${ruby_type}" = "jruby" ]; then
-    local dir_name="jruby-${ruby_version}"
-  fi
-
-  echo "$tmp_download_dir/$dir_name"
-}
-
-
-get_download_url() {
-  local install_type=$1
-  local version=$2
-
-  local ruby_type=$(get_ruby_type $version)
-  local ruby_version=$(get_ruby_version $version)
-
-  if [ "${ruby_type}" = "ruby" ]; then
-    echo "https://cache.ruby-lang.org/pub/ruby/ruby-${ruby_version}.tar.gz"
-  elif [ "${ruby_type}" = "jruby" ]; then
-    echo "https://s3.amazonaws.com/jruby.org/downloads/${ruby_version}/jruby-bin-${ruby_version}.tar.gz"
-  fi
-}
-
-get_ruby_version() {
-  IFS='-' read -a version_info <<< "$1"
-
-  if [ "${version_info[0]}" = "jruby" ]; then
-    # jruby
-    if [ "${#version_info[@]}" -eq 2 ]; then
-      echo "${version_info[1]}"
-    else
-      echo "${version_info[1]}-${version_info[2]}"
-    fi
-  else
-    # ruby
-    if [ "${#version_info[@]}" -eq 1 ]; then
-      echo "${version_info[0]}"
-    else
-      echo "${version_info[0]}-${version_info[1]}"
-    fi
-  fi
-}
-
-
-get_ruby_type() {
-  IFS='-' read -a version_info <<< "$1"
-  if [ "${version_info[0]}" = "jruby" ]; then
-    echo "jruby"
-  else
-    echo "ruby"
-  fi
-}
-
 
 install_default_gems() {
   local default_gems="${HOME}/.default-gems"
@@ -276,6 +66,6 @@ install_default_gems() {
   done
 }
 
-
+ensure_ruby_build_available
 install_ruby $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
 install_default_gems

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,29 +1,13 @@
 #!/usr/bin/env bash
 
-RUBY_VERSIONS_URL=https://raw.githubusercontent.com/postmodern/ruby-versions/master/ruby/versions.txt
-JRUBY_VERSIONS_URL=https://raw.githubusercontent.com/postmodern/ruby-versions/master/jruby/versions.txt
+set -euo pipefail
 
-function get_versions() {
-  curl --silent $1
+# shellcheck source=../lib/utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/utils.sh"
+
+list_versions() {
+  ruby-build --definitions | paste -sd " " -
 }
 
-ruby_versions=$(
-  get_versions $RUBY_VERSIONS_URL
-)
-jruby_versions=$(
-  get_versions $JRUBY_VERSIONS_URL
-)
-
-versions=""
-
-for version in ${jruby_versions[@]}
-do
-  versions="${versions} jruby-${version}"
-done
-
-for version in ${ruby_versions[@]}
-do
-  versions="${versions} ${version}"
-done
-
-echo $versions
+ensure_ruby_build_available
+list_versions

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,0 +1,11 @@
+echoerr() {
+  >&2 echo -e "\033[0;31m$1\033[0m"
+}
+
+ensure_ruby_build_available() {
+  if [ ! -x "$(command -v ruby-build)" ]; then
+    echoerr "Please install ruby-build first"
+    echoerr "See https://github.com/rbenv/ruby-build#installation"
+    exit 1
+  fi
+}


### PR DESCRIPTION
@Stratus3D After our discussion in #38 I started working on integrating ruby-build into asdf-ruby. Everything seems to be working fine but this obviously needs some extensive testing and is still at an early stage. For now I've just manually tested the commands under macOS.

I realize that this is a rather drastic change in direction for this project but I think it does not make much sense to try and keep up with the latest Ruby versions, platforms etc. when we can use another project that is already doing a good job at this.

One open question is whether we want to leave it up to the user to install `ruby-build` themselves or have our own copy inside asdf-ruby. If we include it we also need to keep it up to date and so on, otherwise we can rely on OS package managers to do the work for us.

Feedback is very welcome!