### PR TITLE
Fix patch relative path reference

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -37,7 +37,7 @@ fetch_patches() {
 
 get_absolute_path() {
   local start_dir=$(pwd)
-  local rel_path=$2
+  local rel_path=$1
   local rel_dir=$(dirname "$rel_path")
   local rel_base=$(basename "$rel_path")
 


### PR DESCRIPTION
`get_absolute_path` is called with the patch file path as the first
argument.

This commit fixes the relative path reference in the function to use
the value of the first argument passed into it.