### PR TITLE
added support for pseudo-gemsets a la rvm

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -9,7 +9,9 @@ install_ruby() {
   ensure_ruby_build_setup
 
   local install_type=$1
-  local version=$2
+  local raw_version=$2
+  local version=${raw_version%%@*}
+  local gemset=${raw_version##*@}
   local install_path=$3
 
   if [ "$install_type" != "version" ]; then

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -1,15 +1,33 @@
 #!/usr/bin/env bash
 
 get_legacy_version() {
-  ruby_version_file=$1
+  legacy_version_path=$1
+  current_directory=${legacy_version_path%/*}
+  current_filename=${legacy_version_path##*/}
+  ruby_version=
 
-  # Get version from .ruby-version file (filters out 'ruby-' prefix if it exists).
-  # The .ruby-version is used by rbenv and now rvm.
-  if [ -f "$ruby_version_file" ]; then
-    ruby_version=$(cat "$ruby_version_file")
-    ruby_prefix="ruby-"
-    echo ${ruby_version/#$ruby_prefix}
+  if [ "$current_filename" == ".ruby-version" ]; then
+    ruby_version_file="$current_directory/.ruby-version"
+
+    # Get version from .ruby-version file (filters out 'ruby-' prefix if it exists).
+    # The .ruby-version is used by rbenv and now rvm.
+    if [ -f "$ruby_version_file" ]; then
+      ruby_version=$(< "$ruby_version_file")
+      ruby_prefix="ruby-"
+      ruby_version=${ruby_version/#$ruby_prefix}
+    fi
+
+    # Get rvm-style gemset from .ruby-gemset file and append that to the version for a
+    # pseudo-gemset functionality (no inheritance between this and a global gemset e.g.)
+    ruby_gemset_file="$current_directory/.ruby-gemset"
+
+    if [ -f "$ruby_gemset_file" ]; then
+      raw_ruby_gemset=$(< "$ruby_gemset_file")
+      ruby_version=${ruby_version}@${raw_ruby_gemset}
+    fi
   fi
+
+  echo $ruby_version
 }
 
 get_legacy_version "$1"


### PR DESCRIPTION
install a gemset like so:

asdf install ruby 2.5.1@my_gemset

This will install ruby 2.5.1 in:
  ~/.asdf/installs/ruby/2.5.1@my_gemset

use a gemset in the following ways:

1. add a .ruby-gemset file alongside a .ruby-version file like so:

.ruby-version contains "2.5.1"
.ruby-gemset contains "sekret_project"

This will result in using the ruby 2.5.1 installed in:
  ~/.asdf/installs/ruby/2.5.1@sekret_project

2. add gemset information directly to the .ruby-version file:

.ruby-version contains "2.5.1@public"

This will result in using the ruby 2.5.1 installed in:
  ~/.asdf/installs/ruby/2.5.1@public

3. add a .tool-versions file like so:

.tool-versions contains "ruby 2.5.1@another_sekret"

This will result in using the ruby 2.5.1 installed in:
  ~/.asdf/installs/ruby/2.5.1@another_sekret