### PR TITLE
Fix: instructions create a 'ruby' folder inside '~/.asdf/installs/'

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,17 @@ directory:
 
 #### RVM
 
-    mkdir ~/.asdf/installs/
+    mkdir -p ~/.asdf/installs/ruby/
     mv ~/.rvm/rubies ~/.asdf/installs/ruby/
+
 
 #### rbenv
 
-    mkdir ~/.asdf/installs/
+    mkdir -p ~/.asdf/installs/ruby/
     mv ~/.rbenv/versions/* ~/.asdf/installs/ruby/
 
 #### chruby
 
-    mkdir ~/.asdf/installs/
+    mkdir -p ~/.asdf/installs/ruby/
     mv ~/.rubies ~/.asdf/installs/ruby/
+    


### PR DESCRIPTION
If you follow instructions to recover rubies from previous version manager you will run into an error telling you that there is no `ruby` directory inside `~/.asdf/installs`. This is why `mkdir ~/.asdf/installs/` should be replaced by `mkdir -p ~/.asdf/installs/ruby/`.