### PR TITLE
Make new ruby directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,15 @@ directory:
 
 #### RVM
 
-    mkdir ~/.asdf/installs/
+    mkdir -p ~/.asdf/installs/ruby
     mv ~/.rvm/rubies ~/.asdf/installs/ruby/
 
 #### rbenv
 
-    mkdir ~/.asdf/installs/
+    mkdir -p ~/.asdf/installs/ruby
     mv ~/.rbenv/versions/* ~/.asdf/installs/ruby/
 
 #### chruby
 
-    mkdir ~/.asdf/installs/
+    mkdir -p ~/.asdf/installs/ruby
     mv ~/.rubies ~/.asdf/installs/ruby/


### PR DESCRIPTION
When trying to `mv` the old files by following the instructions, the command fails with a generic and unhelpful "usage" help text for `mv`. In fact, the issue is that we are trying to copy the globbed files into a directory that does not yet exist.