### PR TITLE
Fix deprecated legacy version file parsing

### DIFF
--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 get_legacy_version() {
-  current_directory=$1
-  ruby_version_file="$current_directory/.ruby-version"
+  ruby_version_file=$1
 
   # Get version from .ruby-version file (filters out 'ruby-' prefix if it exists).
   # The .ruby-version is used by rbenv and now rvm.


### PR DESCRIPTION
This updates asdf-ruby to use the new `parse-legacy-file` script. It was previously ignoring the legacy version file since it was never calling this script.

Fixes #84 