### PR TITLE
support desired gem versions in .default-gems

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -59,15 +59,36 @@ install_default_gems() {
 
   echo ""
 
-  while read -r name_and_optional_gem_install_options; do
-    echo -n "Running: gem install ${name_and_optional_gem_install_options} ... "
+  # Parsing of .default-gems was originally lifted from rbenv-default-gems
+  # which is Copyright (c) 2013 Sam Stephenson
+  # https://github.com/rbenv/rbenv-default-gems/blob/ead6788/LICENSE
+  while IFS=" " read -r -a line; do
 
-    if $gem install $name_and_optional_gem_install_options > /dev/null 2>&1; then
+    # Skip empty lines.
+    [ "${#line[@]}" -gt 0 ] || continue
+
+    # Skip comment lines that begin with `#`.
+    [ "${line[0]:0:1}" != "#" ] || continue
+
+    gem_name="${line[0]}"
+    gem_version="${line[1]-}"
+
+    if [ "$gem_version" == "--pre" ]; then
+      args=( --pre )
+    elif [ -n "$gem_version" ]; then
+      args=( --version "$gem_version" )
+    else
+      args=()
+    fi
+
+    echo -n "Running: gem install "$gem_name" "${args[@]}" ... "
+
+    if $gem install "$gem_name" "${args[@]}" > /dev/null 2>&1; then
       echo -e "SUCCESS"
     else
       echo -e "FAIL"
     fi
-  done <<< "$(cat "$default_gems")"
+  done < "$default_gems"
 }
 
 install_ruby "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/install
+++ b/bin/install
@@ -59,10 +59,10 @@ install_default_gems() {
 
   echo ""
 
-  while read -r name; do
-    echo -n "Installing ${name} gem... "
+  while read -r name_and_optional_gem_install_options; do
+    echo -n "Running: gem install ${name_and_optional_gem_install_options} ... "
 
-    if $gem install "$name" > /dev/null 2>&1; then
+    if $gem install $name_and_optional_gem_install_options > /dev/null 2>&1; then
       echo -e "SUCCESS"
     else
       echo -e "FAIL"


### PR DESCRIPTION
you know how bundler 2 just came out and doesn't work with old ruby versions? this will hopefully lessen the consternation around this by allowing folks to opt in to a specific version of gems in their asdf-ruby .default-versions file.

here's my old one:

    ~ % cat .default-gems
    bundler

and my new one:

    ~ % cat .default-gems
    bundler 1.17.3

both are now supported.

thanks a ton for maintaining asdf-ruby! have you considered using the ruby-install project instead of ruby-build?