### PR TITLE
Support a local .default-gems file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ pry
 gem-ctags
 ```
 
+If you provide a `.default-gems` next to the `.tool-versions` file, asdf-ruby
+will use that instead.
+
 ## Migrating from another Ruby version manager
 
 ### `.ruby-version` file

--- a/bin/install
+++ b/bin/install
@@ -70,11 +70,16 @@ get_absolute_path() {
 
 install_default_gems() {
   local args=()
-  local default_gems="${HOME}/.default-gems"
+  local home_default_gems="${HOME}/.default-gems"
+  local default_gems=".default-gems"
   local gem="${ASDF_INSTALL_PATH}/bin/gem"
 
   if [ ! -f "$default_gems" ]; then
-    return;
+    if [ -f "$home_default_gems" ]; then
+      default_gems=$home_default_gems
+    else
+      return;
+    fi
   fi
 
   echo ""


### PR DESCRIPTION
Building on top of #98, this PR gives priority to a `.default-gems` file if it exists, falling back to `${HOME}/.default-gems` otherwise. This allows projects to ship specific gems that are outside of the realm of their `Gemfile`.

To give you a concrete example, bundler is very sensitive to the version of bundler the `Gemfile.lock` was created with. Today, doing a "gem install bundler" will install bundler 2.0.1. If the `Gemfile.lock` was created with bundler version 1.17.2, the user will get an error like below:

```
$ bundle
Traceback (most recent call last):
	2: from /Users/kamal/.asdf/installs/ruby/2.5.3/bin/bundle:23:in `<main>'
	1: from /Users/kamal/.asdf/installs/ruby/2.5.3/lib/ruby/2.5.0/rubygems.rb:308:in `activate_bin_path'
/Users/kamal/.asdf/installs/ruby/2.5.3/lib/ruby/2.5.0/rubygems.rb:289:in `find_spec_for_exe': can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException)
```

It was not obvious that the solution was to install bundler with the expected version. Now my project ships with `.tool-versions` and `.default-gems`.