### PR TITLE
Change default-gems path to be relative to ASDF_CONFIG_FILE

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -68,9 +68,22 @@ get_absolute_path() {
   )
 }
 
+default_gem_path() {
+  local config_path=${ASDF_CONFIG_FILE:-"$HOME/.asdfrc"}
+  local config_dir=$(dirname "$config_path")
+  
+  if [ -f "${config_dir}/default-gems" ]; then
+    echo "${config_dir}/default-gems"
+  elif [ -f "${config_dir}/.default-gems" ]; then
+    echo "${config_dir}/.default-gems"
+  else
+    echo "${HOME}/.default-gems"
+  fi
+}
+
 install_default_gems() {
   local args=()
-  local default_gems="${HOME}/.default-gems"
+  local default_gems=$(default_gem_path)
   local gem="${ASDF_INSTALL_PATH}/bin/gem"
 
   if [ ! -f "$default_gems" ]; then


### PR DESCRIPTION
This changes the path to the `default-gems` file so that asdf-ruby now looks for it in the same directory as the `asdfrc`. It now checks for `default-gems` and `.default-gems` in that directory and then falls back to the current value of `${HOME}/.default-gems`.