### PR TITLE
Skip recompiling openssl for truffleruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: c
 script: asdf plugin-test ruby https://github.com/asdf-vm/asdf-ruby.git
 before_script:
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export TRUFFLERUBY_RECOMPILE_OPENSSL=false; fi
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh
 os:
   - linux
   - osx
-addons:
-  homebrew:
-    packages:
-      - llvm@4


### PR DESCRIPTION
asdf plugin-test on Travis appears failing the installation of Truffleruby on macos due to the failure of openssl recompilation.

This PR make it [skip recompiling openssl](https://github.com/oracle/truffleruby/blob/f08dd1ac65f22da9bb976ee8792429bfce6d04c5/lib/truffle/post_install_hook.sh#L23) until the issue be fixed on TruffleRuby's side (oracle/truffleruby#1417).

Thoughts?