### PR TITLE
Fix install / list-all commands always re-download ruby-build

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -17,6 +17,11 @@ ensure_ruby_build_installed() {
         download_ruby_build
     else
         current_ruby_build_version="$("$(ruby_build_path)" --version | cut -d ' ' -f2)"
+        # If ruby-build version does not start with 'v',
+        # add 'v' to beginning of version
+        if [ ${current_ruby_build_version:0:1} != "v" ]; then
+          current_ruby_build_version="v$current_ruby_build_version"
+        fi
         if [ "$current_ruby_build_version" != "$RUBY_BUILD_VERSION" ]; then
             # If the ruby-build directory already exists and the version does not
             # match, remove it and download the correct version


### PR DESCRIPTION
Summary:

`$RUBY_BUILD_VERSION` is actually tag name, it starts with `v`, for example `v20190828`, and it always be different with version that is parsed from `ruby-build --version`. Because of this, `asdf list-all ruby` or `asdf install ruby` always trigger re-downloading `ruby-build` source.

```bash
asdf-ruby (master) $ ~/.asdf/plugins/ruby/ruby-build/bin/ruby-build --version
ruby-build 20190828

asdf-ruby (master) $ ~/.asdf/plugins/ruby/ruby-build/bin/ruby-build --version | cut -d ' ' -f2
20190828
```
