### PR TITLE
Fix output of `asdf list-all ruby` when downloading ruby-build

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -13,4 +13,4 @@ list_versions() {
   "$(ruby_build_path)" --definitions | grep -v "topaz-dev" | paste -sd " " -
 }
 
-list_versions 2> /dev/null
+list_versions

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -6,7 +6,6 @@ echoerr() {
 }
 
 ensure_ruby_build_setup() {
-  #set_ruby_build_env
   ensure_ruby_build_installed
 }
 
@@ -56,6 +55,3 @@ ruby_build_dir() {
 ruby_build_path() {
     echo "$(ruby_build_dir)/bin/ruby-build"
 }
-
-#set_ruby_build_env() {
-#}

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -32,8 +32,11 @@ ensure_ruby_build_installed() {
 
 download_ruby_build() {
     # Print to stderr so asdf doesn't assume this string is a list of versions
-    echo "Downloading ruby-build..." >&2
-    local build_dir="$(asdf_ruby_plugin_path)/ruby-build-source"
+    echoerr "Downloading ruby-build..."
+    local build_dir="$(ruby_build_source_dir)"
+
+    # Remove directory in case it still exists from last download
+    rm -rf $build_dir
 
     # Clone down and checkout the correct ruby-build version
     git clone https://github.com/rbenv/ruby-build.git $build_dir >&2 >/dev/null
@@ -52,6 +55,11 @@ asdf_ruby_plugin_path() {
 ruby_build_dir() {
     echo "$(asdf_ruby_plugin_path)/ruby-build"
 }
+
+ruby_build_source_dir() {
+    echo "$(asdf_ruby_plugin_path)/ruby-build-source"
+}
+
 ruby_build_path() {
     echo "$(ruby_build_dir)/bin/ruby-build"
 }


### PR DESCRIPTION
We are currently hiding all output written to STDERR when running the `list-all` script. The STDERR output is useful as it is used to display info on the ruby-build download.