### PR TITLE
Fix auto-reshim on bundle install and gem uninstall.

### DIFF
--- a/rubygems-plugin/rubygems_plugin.rb
+++ b/rubygems-plugin/rubygems_plugin.rb
@@ -1,11 +1,18 @@
-# Yes borrowed from rbenv. Couldn't take my mind off that implementation
-
-Gem.post_install do |installer|
-
-  if installer.spec.executables.any? && installer.bin_dir == Gem.default_bindir
-    installer.spec.executables.each do |executable|
-     `asdf reshim ruby #{RUBY_VERSION} bin/#{executable}`
-    end
+module ReshimInstaller
+  def install(options)
+    super
+    # We don't know which gems were installed, so always reshim.
+    `asdf reshim ruby`
   end
+end
 
+if defined?(Bundler::Installer)
+  Bundler::Installer.prepend ReshimInstaller
+else
+  maybe_reshim = lambda do |installer|
+    # If any gems with executables were installed or uninstalled, reshim.
+    `asdf reshim ruby` if installer.spec.executables.any?
+  end
+  Gem.post_install &maybe_reshim
+  Gem.post_uninstall &maybe_reshim
 end

--- a/rubygems-plugin/rubygems_plugin.rb
+++ b/rubygems-plugin/rubygems_plugin.rb
@@ -9,10 +9,15 @@ end
 if defined?(Bundler::Installer)
   Bundler::Installer.prepend ReshimInstaller
 else
-  maybe_reshim = lambda do |installer|
-    # If any gems with executables were installed or uninstalled, reshim.
+  Gem.post_install do |installer|
+    # Reshim any (potentially) new executables.
+    installer.spec.executables.each do |executable|
+      `asdf reshim ruby #{RUBY_VERSION} bin/#{executable}`
+    end
+  end
+  Gem.post_uninstall do |installer|
+    # Unfortunately, reshimming just the removed executables or
+    # ruby version doesn't work as of 2020/04/23.
     `asdf reshim ruby` if installer.spec.executables.any?
   end
-  Gem.post_install &maybe_reshim
-  Gem.post_uninstall &maybe_reshim
 end


### PR DESCRIPTION
This fixes #63 but depends on https://github.com/rubygems/rubygems/pull/3534 being merged in order to actually work. There is a long-standing bug in bundler that prevents it from loading `rubygems_plugin.rb` from `RUBYLIB`. However, there is no problem having this hook exist with a version of bundler that doesn't support it -- this file will just never be evaluated in that case.

It also fixes shims not being removed on `gem uninstall` where installer.bin_dir is not set, so it can never match `Gem.default_bindir`. Additionally, the `#{RUBY_VERSION} bin/#{executable}` syntax does not work for removing shims, so in the interest of simplicity, the hook now just runs `asdf reshim ruby` which works in both the install and uninstall cases, but is potentially less efficient for installation via `gem install`.