### PR TITLE
Fix marshal data too short error for default gems

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -103,7 +103,7 @@ install_default_gems() {
 
     echo -n "Running: gem install $gem_name ${args[@]:-} ... "
 
-    if output=$($gem install "$gem_name" "${args[@]:-}" 2>&1); then
+    if output=$($gem install "$gem_name" "${args[@]+"${args[@]}"}" 2>&1); then
       echo -e "SUCCESS"
     else
       echo -e "FAIL: $output"


### PR DESCRIPTION
This fixes #150 which happens when there's no version specified for gems in `$HOME/.default-gems` file.