### PR TITLE
Replacing ruby-build with ruby-install.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ruby-build
+ruby-build-source

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-ruby-build
-ruby-build-source
+ruby-install
+ruby-install-source

--- a/README.md
+++ b/README.md
@@ -10,28 +10,45 @@ Ruby plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 asdf plugin-add ruby https://github.com/asdf-vm/asdf-ruby.git
 ```
 
-Please make sure you have the required [system dependencies](https://github.com/rbenv/ruby-build/wiki#suggested-build-environment) installed before trying to install Ruby.
+Please make sure you have the required [system dependencies](https://github.com/postmodern/ruby-install#requirements) installed before trying to install Ruby.
+
+By default, asdf-ruby will try to rely as much as it can on your [package manager](https://github.com/postmodern/ruby-install#features) for both using ruby-install as well as fetching necessary dependencies to build from source.
 
 ## Use
 
 Check [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install & manage versions of Ruby.
 
-When installing Ruby using `asdf install`, you can pass custom configure options with the [env vars supported by ruby-build](https://github.com/rbenv/ruby-build#custom-build-configuration).
+When installing Ruby using `asdf install`, you can pass custom configure options with the [env vars supported by ruby-install](https://github.com/postmodern/ruby-install#synopsis).
 
-Under the hood, asdf-ruby uses [ruby-build](https://github.com/rbenv/ruby-build) to build and install Ruby, check its [README](https://github.com/rbenv/ruby-build/blob/master/README.md) for more information about build options and the [troubleshooting](https://github.com/rbenv/ruby-build/wiki#troubleshooting) wiki section for any issues encountered during installation of ruby versions.
+Under the hood, asdf-ruby uses [ruby-install](https://github.com/postmodern/ruby-install) to build and install Ruby, check its [README](https://github.com/postmodern/ruby-install) for more information about build options and the [requirements](https://github.com/postmodern/ruby-install#requirements) section for any issues encountered during installation of ruby versions.
 
 You may also apply custom patches before building with `RUBY_APPLY_PATCHES`, e.g.
 
-```
+```sh
 RUBY_APPLY_PATCHES=$'dir/1.patch\n2.patch\nhttp://example.com/3.patch' asdf install ruby 2.4.1
-RUBY_APPLY_PATCHES=$(curl -s https://raw.githubusercontent.com/rvm/rvm/master/patchsets/ruby/2.1.1/railsexpress) asdf install ruby 2.1.1
+RUBY_APPLY_PATCHES="https://raw.githubusercontent.com/rvm/rvm/master/patchsets/ruby/2.1.1/railsexpress" asdf install ruby 2.1.1
 ```
 
-By default asdf-ruby uses the latest release of ruby-build, but you can choose your own branch/tag through the `ASDF_RUBY_BUILD_VERSION` variable:
+Although unecessary with ruby-install, you can still pass custom options
 
+```sh
+RUBY_CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl@1.1)" asdf install ruby 2.4.0
 ```
-ASDF_RUBY_BUILD_VERSION=master asdf install ruby 2.6.4
+
+```sh
+RUBY_CONFIGURE_OPTS="--enable-shared --enable-dtrace CFLAGS="-O3"" asdf install ruby 2.4.0
 ```
+
+By default asdf-ruby uses the latest release of ruby-install, but you can choose your own branch/tag through the `ASDF_RUBY_INSTALL_VERSION` variable:
+
+```sh
+ASDF_RUBY_INSTALL_VERSION="v0.8.0" asdf install ruby 2.6.4
+```
+
+```sh
+ASDF_RUBY_INSTALL_VERSION="master" asdf install ruby 2.6.4
+```
+
 
 ## Default gems
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ RUBY_CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl@1.1)" asdf insta
 ```
 
 ```sh
-RUBY_CONFIGURE_OPTS="--enable-shared --enable-dtrace CFLAGS="-O3"" asdf install ruby 2.4.0
+RUBY_CONFIGURE_OPTS="--disable-install-doc" asdf install ruby 3.0.0
 ```
 
 By default asdf-ruby uses the latest release of ruby-install, but you can choose your own branch/tag through the `ASDF_RUBY_INSTALL_VERSION` variable:

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -3,10 +3,13 @@
 current_script_path=${BASH_SOURCE[0]}
 ruby_plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
+load_os=("$install_path/lib/ruby/$version/"*"-darwin19")
+export LOAD_PATH="${load_os[@]}:$install_path/lib/ruby/$version:$LOAD_PATH"
+
 if [ "$RUBYLIB" = "" ]; then
-  export RUBYLIB="$ruby_plugin_dir/rubygems-plugin"
+  export RUBYLIB="$LOAD_PATH:$ruby_plugin_dir/rubygems-plugin"
 else
-  export RUBYLIB="$ruby_plugin_dir/rubygems-plugin:$RUBYLIB"
+  export RUBYLIB="$LOAD_PATH:$ruby_plugin_dir/rubygems-plugin:$RUBYLIB"
 fi
 
 export PATH=$install_path/bin:$PATH

--- a/bin/install
+++ b/bin/install
@@ -25,8 +25,8 @@ install_ruby() {
     patches=" --patch $RUBY_APPLY_PATCHES "
   fi
 
-  if [[ -n "${RUBY_BUILD_OPTS:-}" ]]; then
-    opts="-- $RUBY_BUILD_OPTS"
+  if [[ -n "${RUBY_CONFIGURE_OPTS:-}" ]]; then
+    opts="-- $RUBY_CONFIGURE_OPTS"
   fi
 
   local command="$(ruby_install_path) --no-reinstall --cleanup --src-dir "$ASDF_DOWNLOAD_PATH" --install-dir "$install_path""$patches""$version" "$opts""

--- a/bin/install
+++ b/bin/install
@@ -6,7 +6,7 @@ set -euo pipefail
 source "$(dirname $0)/../lib/utils.sh"
 
 install_ruby() {
-  ensure_ruby_build_setup
+  ensure_ruby_install_setup
 
   local install_type=$1
   local version=$2
@@ -19,54 +19,21 @@ install_ruby() {
   fi
 
   local opts=""
-  local patches=""
+  local patches=" "
 
   if [[ -n "${RUBY_APPLY_PATCHES:-}" ]]; then
-    opts="$opts --patch"
-    patches=$(fetch_patches "$RUBY_APPLY_PATCHES")
+    patches=" --patch $RUBY_APPLY_PATCHES "
   fi
 
   if [[ -n "${RUBY_BUILD_OPTS:-}" ]]; then
-    opts="$opts $RUBY_BUILD_OPTS"
+    opts="-- $RUBY_BUILD_OPTS"
   fi
 
-  # shellcheck disable=SC2086
-  echo "$patches" | $(ruby_build_path) ${opts} "$version" "$install_path"
+  local command="$(ruby_install_path) --no-reinstall --cleanup --src-dir "$ASDF_DOWNLOAD_PATH" --install-dir "$install_path""$patches""$version" "$opts""
+  echo "$command"
+  echo $($command)
 }
 
-fetch_patches() {
-  while read -r line; do
-    if [ "$line" = "" ]; then continue; fi
-    if [[ "$line" =~ ^[Hh][Tt][Tt][Pp][Ss]?:// ]]; then
-      >&2 echo "Using patch from URL: $line"
-      curl -fSs "$line" || exit 1
-    else
-      local abs_path
-      abs_path="$(get_absolute_path "$line")"
-      >&2 echo "Using local patch: $abs_path"
-      cat "$abs_path" || exit 1
-    fi
-  done <<< "$@"
-}
-
-get_absolute_path() {
-  local start_dir
-  local rel_path
-  local rel_dir
-  local rel_base
-
-  start_dir=$(pwd)
-  rel_path=$1
-  rel_dir=$(dirname "$rel_path")
-  rel_base=$(basename "$rel_path")
-
-  (
-    cd "$start_dir" \
-      && cd "$rel_dir" 2>/dev/null \
-      && echo "$(pwd)/$rel_base" \
-      || echo "$rel_path"
-  )
-}
 
 install_default_gems() {
   local args=()

--- a/bin/install
+++ b/bin/install
@@ -4,9 +4,9 @@ set -euo pipefail
 
 # shellcheck source=../lib/utils.sh
 source "$(dirname $0)/../lib/utils.sh"
+ensure_ruby_install_setup
 
 install_ruby() {
-  ensure_ruby_install_setup
 
   local install_type=$1
   local version=$2
@@ -29,7 +29,7 @@ install_ruby() {
     opts="-- $RUBY_CONFIGURE_OPTS"
   fi
 
-  local command="$(ruby_install_path) --no-reinstall --cleanup --src-dir "$ASDF_DOWNLOAD_PATH" --install-dir "$install_path""$patches""$version" "$opts""
+  local command="$(ruby_install_executable) --no-reinstall --cleanup --src-dir "$ASDF_DOWNLOAD_PATH" --install-dir "$install_path""$patches""$version" "$opts""
   echo "$command"
   echo $($command)
 }

--- a/bin/install
+++ b/bin/install
@@ -8,16 +8,28 @@ ensure_ruby_install_setup
 
 install_ruby() {
 
-  local install_type=$1
-  local version=$2
-  local install_path=$3
 
-  if [ "$install_type" != "version" ]; then
+  if [ "$ASDF_INSTALL_TYPE" != "version" ]; then
     printerr "Cannot install specific ref from source, sorry."
     printerr "For a list of available versions, see \`asdf list-all ruby\`"
     exit 1
   fi
 
+  if [ -z "${RUBY_APPLY_PATCHES:-}" ] && [ -z "${RUBY_CONFIGURE_OPTS:-}"] && [ -z "${ASDF_RUBY_FROM_SOURCE:-}" ] && os_name="$(get_macos_marketing_name)"; then
+    if download_url="$(macos_get_download_url $os_name)"; then
+      macos_install_from_prebuilt "$download_url"
+    else
+      printf 'Fallback to building from source. \n'
+      install_from_source
+    fi
+  else
+    install_from_source
+  fi
+
+
+}
+
+install_from_source() {
   local opts=""
   local patches=" "
 
@@ -29,10 +41,61 @@ install_ruby() {
     opts="-- $RUBY_CONFIGURE_OPTS"
   fi
 
-  local command="$(ruby_install_executable) --no-reinstall --cleanup --src-dir "$ASDF_DOWNLOAD_PATH" --install-dir "$install_path""$patches""$version" "$opts""
+  local command="$(ruby_install_executable) --no-reinstall --cleanup --src-dir "$ASDF_DOWNLOAD_PATH" --install-dir "$ASDF_INSTALL_PATH""$patches""$ASDF_INSTALL_VERSION" "$opts""
   echo "$command"
   echo $($command)
 }
+
+macos_install_from_prebuilt() {
+  #macos_check_homebrew_setup
+  mkdir -p "$ASDF_INSTALL_PATH"
+  mkdir -p "$ASDF_DOWNLOAD_PATH"
+
+
+  local tmp_path="$HOME/.asdf/tmp/$(plugin_name)/extracted/$ASDF_INSTALL_VERSION"
+  mkdir -p "$tmp_path"
+
+
+  local download_url="$1"
+
+  printf 'Downloading %s. \n' "$download_url"
+
+  curl -L "$download_url" | tar xzf - -C "$tmp_path" --strip-components=2
+
+
+  # We're not keeping the same directory structure as Homebrew.
+  local replacement_cellar_pattern="@@HOMEBREW_CELLAR@@/ruby/$ASDF_INSTALL_VERSION"
+
+  # Replace the homebrew URL with something compatible with asdf
+  grep -rlI --null "$replacement_cellar_pattern" "$tmp_path" | xargs -0 sed -i '' "s:$replacement_cellar_pattern:$ASDF_INSTALL_PATH:g"
+
+  local replacement_prefix_pattern="@@HOMEBREW_PREFIX@@"
+
+  # Replace the homebrew URL with something compatible with asdf
+  grep -rlI --null "$replacement_prefix_pattern" "$tmp_path" | xargs -0 sed -i '' "s:$replacement_prefix_pattern:$ASDF_INSTALL_PATH:g"
+
+ local pattern="@@HOMEBREW_CELLAR@@"
+ local linked_libs=()
+  while IFS= read -r -d '' file_path; do
+    linked_libs+=("$file_path")
+  done < <(grep -rl --null "$pattern" "$tmp_path") 
+      
+  macos_update_linked_paths "${linked_libs[@]}"
+
+  mv -f "$tmp_path/"* "$ASDF_INSTALL_PATH"
+
+  local lib_rubies=("$ASDF_INSTALL_PATH/lib/libruby."*".dylib")
+  
+  for lib_ruby in "${lib_rubies[@]}"; do
+    echo "$lib_ruby"
+    $(install_name_tool -id "$lib_ruby" "$lib_ruby")
+    cp "$lib_ruby" "$lib_ruby.backup"
+    codesign -s - -f -vvvvvv "$lib_ruby.backup"
+    mv -f "$lib_ruby.backup" "$lib_ruby"
+  done
+
+}
+
 
 
 install_default_gems() {
@@ -78,5 +141,5 @@ install_default_gems() {
   done < "$default_gems"
 }
 
-install_ruby "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
+install_ruby 
 install_default_gems

--- a/bin/install
+++ b/bin/install
@@ -13,8 +13,8 @@ install_ruby() {
   local install_path=$3
 
   if [ "$install_type" != "version" ]; then
-    echoerr "Cannot install specific ref from source, sorry."
-    echoerr "For a list of available versions, see \`asdf list-all ruby\`"
+    printerr "Cannot install specific ref from source, sorry."
+    printerr "For a list of available versions, see \`asdf list-all ruby\`"
     exit 1
   fi
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -6,11 +6,8 @@ set -euo pipefail
 source "$(dirname $0)/../lib/utils.sh"
 
 list_versions() {
-  ensure_ruby_build_setup
-
-  # This sed command was a quick and dirty solution to remove topaz-dev from
-  # the version list, since it doesn't exist
-  "$(ruby_build_path)" --definitions | grep -v "topaz-dev" | paste -sd " " -
+  ensure_ruby_install_setup
+  echo $($(ruby_install_path))
 }
 
 list_versions

--- a/bin/list-all
+++ b/bin/list-all
@@ -4,10 +4,11 @@ set -euo pipefail
 
 # shellcheck source=../lib/utils.sh
 source "$(dirname $0)/../lib/utils.sh"
+ensure_ruby_install_setup
 
 list_versions() {
-  ensure_ruby_install_setup
-  echo $($(ruby_install_path))
+
+  echo $($(ruby_install_executable))
 }
 
 list_versions

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -16,8 +16,7 @@ ensure_ruby_install_installed() {
       current_ruby_install_version="v$("$(ruby_install_path)" --version | cut -d ' ' -f2)"
       # Check if expected version matches current version
       if [ "$current_ruby_install_version" != "$RUBY_INSTALL_VERSION" ]; then
-        # If not reinstall and checkout ASDF_RUBY_INSTALL_VERSION
-        rm -rf "$(ruby_install_dir)"
+        # If not, reinstall with ASDF_RUBY_INSTALL_VERSION
         download_ruby_install
       fi
     fi
@@ -30,20 +29,21 @@ ensure_ruby_install_installed() {
 
 
 download_ruby_install() {
+  # Remove directory in case it still exists from last download
+  rm -rf "$(ruby_install_source_dir)"
+  rm -rf "$(ruby_install_dir)"
   # Print to stderr so asdf doesn't assume this string is a list of versions
   echoerr "Downloading ruby-install $RUBY_INSTALL_VERSION"
-  local build_dir="$(ruby_install_source_dir)"
 
-  # Remove directory in case it still exists from last download
-  rm -rf "$build_dir"
+
 
   # Clone down and checkout the correct ruby-install version
-  git clone https://github.com/postmodern/ruby-install.git "$build_dir" --quiet
-  (cd "$build_dir"; git checkout $RUBY_INSTALL_VERSION --quiet;)
+  git clone https://github.com/postmodern/ruby-install.git "$(ruby_install_source_dir)" --quiet
+  (cd "$(ruby_install_source_dir)"; git checkout $RUBY_INSTALL_VERSION --quiet;)
 
-  echo "$(cd $build_dir; PREFIX=$(ruby_install_dir) make install)" 2>&1 >/dev/null
+  echo "$(cd $(ruby_install_source_dir); PREFIX=$(ruby_install_dir) make install)" 2>&1 >/dev/null
 
-  rm -rf "$build_dir"
+  rm -rf "$(ruby_install_source_dir)"
 }
 
 asdf_ruby_plugin_path() {

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,65 +1,68 @@
-RUBY_BUILD_VERSION="${ASDF_RUBY_BUILD_VERSION:-v20201225}"
-RUBY_BUILD_TAG="$RUBY_BUILD_VERSION"
+RUBY_INSTALL_VERSION="${ASDF_RUBY_INSTALL_VERSION:-v0.8.1}"
 
 echoerr() {
   >&2 echo -e "\033[0;31m$1\033[0m"
 }
 
-ensure_ruby_build_setup() {
-  ensure_ruby_build_installed
+ensure_ruby_install_setup() {
+  ensure_ruby_install_installed
 }
 
-ensure_ruby_build_installed() {
-    local ruby_build_version
-
-    if [ ! -f "$(ruby_build_path)" ]; then
-        download_ruby_build
-    else
-        current_ruby_build_version="$("$(ruby_build_path)" --version | cut -d ' ' -f2)"
-        # If ruby-build version does not start with 'v',
-        # add 'v' to beginning of version
-        if [ ${current_ruby_build_version:0:1} != "v" ]; then
-          current_ruby_build_version="v$current_ruby_build_version"
-        fi
-        if [ "$current_ruby_build_version" != "$RUBY_BUILD_VERSION" ]; then
-            # If the ruby-build directory already exists and the version does not
-            # match, remove it and download the correct version
-            rm -rf "$(ruby_build_dir)"
-            download_ruby_build
-        fi
+ensure_ruby_install_installed() {
+  # If ruby-install exists
+  if [ -x "$(ruby_install_path)" ]; then
+    # But was passed an expected version
+    if [ -n "${ASDF_RUBY_INSTALL_VERSION:-}" ]; then
+      current_ruby_install_version="v$("$(ruby_install_path)" --version | cut -d ' ' -f2)"
+      # Check if expected version matches current version
+      if [ "$current_ruby_install_version" != "$RUBY_INSTALL_VERSION" ]; then
+        # If not reinstall and checkout ASDF_RUBY_INSTALL_VERSION
+        rm -rf "$(ruby_install_dir)"
+        download_ruby_install
+      fi
     fi
+  else
+    # ruby-install does not exist, so install using default value in RUBY_INSTALL_VERSION
+    download_ruby_install
+  fi
 }
 
-download_ruby_build() {
-    # Print to stderr so asdf doesn't assume this string is a list of versions
-    echoerr "Downloading ruby-build..."
-    local build_dir="$(ruby_build_source_dir)"
 
-    # Remove directory in case it still exists from last download
-    rm -rf $build_dir
 
-    # Clone down and checkout the correct ruby-build version
-    git clone https://github.com/rbenv/ruby-build.git $build_dir >&2 >/dev/null
-    (cd $build_dir; git checkout $RUBY_BUILD_TAG >&2 >/dev/null)
+download_ruby_install() {
+  # Print to stderr so asdf doesn't assume this string is a list of versions
+  echoerr "Downloading ruby-install $RUBY_INSTALL_VERSION"
+  local build_dir="$(ruby_install_source_dir)"
 
-    # Install in the ruby-build dir
-    PREFIX="$(ruby_build_dir)" $build_dir/install.sh
+  # Remove directory in case it still exists from last download
+  rm -rf "$build_dir"
 
-    # Remove ruby-build source dir
-    rm -rf $build_dir
+  # Clone down and checkout the correct ruby-install version
+  git clone https://github.com/postmodern/ruby-install.git "$build_dir" --quiet
+  (cd "$build_dir"; git checkout $RUBY_INSTALL_VERSION --quiet;)
+
+  echo "$(cd $build_dir; PREFIX=$(ruby_install_dir) make install)" 2>&1 >/dev/null
+
+  rm -rf "$build_dir"
 }
 
 asdf_ruby_plugin_path() {
-    echo "$(dirname "$(dirname "$0")")"
+  echo "$(dirname "$(dirname "$0")")"
 }
-ruby_build_dir() {
-    echo "$(asdf_ruby_plugin_path)/ruby-build"
-}
-
-ruby_build_source_dir() {
-    echo "$(asdf_ruby_plugin_path)/ruby-build-source"
+ruby_install_dir() {
+  echo "$(asdf_ruby_plugin_path)/ruby-install"
 }
 
-ruby_build_path() {
-    echo "$(ruby_build_dir)/bin/ruby-build"
+ruby_install_source_dir() {
+  echo "$(asdf_ruby_plugin_path)/ruby-install-source"
+}
+
+
+ruby_install_path() {
+  #Check if ruby-install exists without an expected version
+  if [ -x "$(command -v ruby-install)" ] && [ -z "${ASDF_RUBY_INSTALL_VERSION:-}" ]; then
+    echo "$(command -v ruby-install)"
+  else
+    echo "$(ruby_install_dir)/bin/ruby-install"
+  fi
 }

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -71,3 +71,111 @@ ruby_install_executable() {
     echo "$(ruby_install_path)/bin/ruby-install"
   fi
 }
+
+get_macos_marketing_name() {
+  if [ "$(uname -s)" = "Darwin" ]; then
+    osx_num=$(SYSTEM_VERSION_COMPAT=1 sw_vers -productVersion | awk -F '[.]' '{print $2}')
+    OSX_MARKETING=(
+        ["10"]="yosemite"
+        ["11"]="el_capitan"
+        ["12"]="sierra"
+        ["13"]="high_sierra"
+        ["14"]="mojave"
+        ["15"]="catalina"
+        ["16"]="big_sur"
+      )
+
+    if [[ -n "${OSX_MARKETING[$osx_num]}" ]]; then 
+      printf '%s\n' "${OSX_MARKETING[$osx_num]}"
+      return 0
+    else
+      return 1
+    fi
+  else
+    return 1
+  fi
+}
+
+macos_get_download_url() {
+  local os_name=$(
+      if [ "$(uname -m)" = "arm64" ]; then 
+        printf "arm64_%s" "$1"
+      else
+        printf "%s" "$1"
+      fi
+    )
+
+  printf 'Looking for prebuilt %s %s on %s. \n' "$(plugin_name)" "$ASDF_INSTALL_VERSION" "$os_name" >&2
+  local ruby_version="ruby-$ASDF_INSTALL_VERSION"
+  local file_name="$ruby_version.$os_name.bottle.tar.gz"
+  local url="https://bintray.com/homebrew/bottles/download_file?file_path=$file_name"
+
+  if curl --output /dev/null --silent --head --fail "$url"; then
+    printf '%s' $url
+    return 0
+  else
+    printerr 'No prebuilt %s %s for %s is available. ' "$(plugin_name)" "$ASDF_INSTALL_VERSION" "$os_name"
+    return 1
+  fi
+}
+
+macos_update_linked_paths() {
+  
+  local file_paths=("$@")
+  
+  local brew_prefix="$(brew --prefix)"
+  local replacement_cellar="@@HOMEBREW_CELLAR@@/ruby/$ASDF_INSTALL_VERSION"
+
+  local replacement_prefix="@@HOMEBREW_PREFIX@@"
+  
+
+  for file in "${file_paths[@]}"; do
+
+    local changes=()
+    for line in $(otool -L "$file"); do
+      if [[ "$line" == "$replacement_cellar"* ]]; then
+        local result="${line/$replacement_cellar/$ASDF_INSTALL_PATH}"
+        changes+=("-change" "$line" "$result")
+      fi
+      if [[ "$line" == "$replacement_prefix"* ]]; then
+        local result="${line/$replacement_prefix/$brew_prefix}"
+        changes+=("-change" "$line" "$result")
+      fi
+    done
+    local command=(install_name_tool "${changes[@]}" "$file")
+    "${command[@]}"
+
+    # https://github.com/Homebrew/brew/blob/565becc90433df57c9ec6262dec1f41797fb680b/Library/Homebrew/os/mac/keg.rb#L21
+    cp "$file" "$file.backup"
+    codesign -s - -f -vvvvvv "$file.backup"
+    mv -f "$file.backup" "$file"
+  done
+
+
+
+
+}
+
+macos_check_homebrew_setup() {
+  
+  local brew_function="${1:-PREBUILT}"
+  
+  printf 'Checking Homebrew for dependencies. \n'
+  if [ -x "$(command -v brew)" ]; then
+    if [ ! -d "$(brew --prefix openssl)" ]; then
+      printerr 'Missing openssl from Homebrew'
+      printf 'Fix with: brew install openssl \n'
+      exit 1
+    fi
+    if [ ! -d "$(brew --prefix readline)" ]; then
+      printerr 'Missing wxmac from Homebrew'
+      printf 'Fix with: brew install readline \n'
+      exit 1
+    fi
+    return 0
+  else
+      printerr 'Homebrew is not installed or in PATH'
+      printf 'To install without Homebrew, set your own KERL_CONFIGURE_OPTIONS \n'
+      exit 1
+  fi
+}

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,4 +1,4 @@
-RUBY_INSTALL_VERSION="${ASDF_RUBY_INSTALL_VERSION:-v0.8.1}"
+  export RUBY_INSTALL_VERSION="${ASDF_RUBY_INSTALL_VERSION:-v0.8.1}"
 
 echoerr() {
   >&2 echo -e "\033[0;31m$1\033[0m"
@@ -10,10 +10,10 @@ ensure_ruby_install_setup() {
 
 ensure_ruby_install_installed() {
   # If ruby-install exists
-  if [ -x "$(ruby_install_path)" ]; then
+  if [ -x "$(ruby_install_executable)" ]; then
     # But was passed an expected version
     if [ -n "${ASDF_RUBY_INSTALL_VERSION:-}" ]; then
-      current_ruby_install_version="v$("$(ruby_install_path)" --version | cut -d ' ' -f2)"
+      current_ruby_install_version="v$("$(ruby_install_executable)" --version | cut -d ' ' -f2)"
       # Check if expected version matches current version
       if [ "$current_ruby_install_version" != "$RUBY_INSTALL_VERSION" ]; then
         # If not, reinstall with ASDF_RUBY_INSTALL_VERSION
@@ -30,39 +30,44 @@ ensure_ruby_install_installed() {
 
 download_ruby_install() {
   # Remove directory in case it still exists from last download
-  rm -rf "$(ruby_install_source_dir)"
-  rm -rf "$(ruby_install_dir)"
+  rm -rf "$(ruby_install_source_path)"
+  rm -rf "$(ruby_install_path)"
   # Print to stderr so asdf doesn't assume this string is a list of versions
   echoerr "Downloading ruby-install $RUBY_INSTALL_VERSION"
 
 
 
   # Clone down and checkout the correct ruby-install version
-  git clone https://github.com/postmodern/ruby-install.git "$(ruby_install_source_dir)" --quiet
-  (cd "$(ruby_install_source_dir)"; git checkout $RUBY_INSTALL_VERSION --quiet;)
+  git clone https://github.com/postmodern/ruby-install.git "$(ruby_install_source_path)" --quiet
+  (cd "$(ruby_install_source_path)"; git checkout $RUBY_INSTALL_VERSION --quiet;)
 
-  echo "$(cd $(ruby_install_source_dir); PREFIX=$(ruby_install_dir) make install)" 2>&1 >/dev/null
+  echo "$(cd $(ruby_install_source_path); PREFIX=$(ruby_install_path) make install)" 2>&1 >/dev/null
 
-  rm -rf "$(ruby_install_source_dir)"
+  rm -rf "$(ruby_install_source_path)"
 }
 
 asdf_ruby_plugin_path() {
   echo "$(dirname "$(dirname "$0")")"
 }
-ruby_install_dir() {
+
+plugin_name() {
+  basename $(asdf_ruby_plugin_path)
+}
+
+ruby_install_path() {
   echo "$(asdf_ruby_plugin_path)/ruby-install"
 }
 
-ruby_install_source_dir() {
-  echo "$(asdf_ruby_plugin_path)/ruby-install-source"
+ruby_install_source_path() {
+  echo "$(ruby_install_path)-source"
 }
 
 
-ruby_install_path() {
+ruby_install_executable() {
   #Check if ruby-install exists without an expected version
   if [ -x "$(command -v ruby-install)" ] && [ -z "${ASDF_RUBY_INSTALL_VERSION:-}" ]; then
     echo "$(command -v ruby-install)"
   else
-    echo "$(ruby_install_dir)/bin/ruby-install"
+    echo "$(ruby_install_path)/bin/ruby-install"
   fi
 }

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,7 +1,7 @@
   export RUBY_INSTALL_VERSION="${ASDF_RUBY_INSTALL_VERSION:-v0.8.1}"
 
-echoerr() {
-  >&2 echo -e "\033[0;31m$1\033[0m"
+printerr() {
+  >&2 printf '\033[0;31m%s\033[0m \n' "$1"
 }
 
 ensure_ruby_install_setup() {
@@ -33,7 +33,7 @@ download_ruby_install() {
   rm -rf "$(ruby_install_source_path)"
   rm -rf "$(ruby_install_path)"
   # Print to stderr so asdf doesn't assume this string is a list of versions
-  echoerr "Downloading ruby-install $RUBY_INSTALL_VERSION"
+  printerr "Downloading ruby-install $RUBY_INSTALL_VERSION"
 
 
 


### PR DESCRIPTION
* Will use existing `ruby-install` from `$PATH` or fetch specific version when setting `ASDF_RUBY_INSTALL_VERSION`.
* Will allow [ruby-install](https://github.com/postmodern/ruby-install#features) use existing dependencies from a range of package managers instead of building from source.
* Change `git` related commands to be quiet as to not pollute the prompt. 
* Other features enabled by [ruby-install](https://github.com/postmodern/ruby-install#synopsis) like using remote patches.
* Removing `fetch_patches()` as its no longer needed. 
* Fix: https://github.com/asdf-vm/asdf-ruby/issues/204
* Prebuilt binaries for macOS with fallback to ruby-install; opt-out via `ASDF_RUBY_FROM_SOURCE` or `RUBY_CONFIGURE_OPTS`