### PR TITLE
Support non-default .default-gems locations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ pry
 gem-ctags
 ```
 
+You can specify a non-default location of this file by setting a `ASDF_GEM_DEFAULT_PACKAGES_FILE` variable.
+
 ## Migrating from another Ruby version manager
 
 ### `.ruby-version` file

--- a/bin/install
+++ b/bin/install
@@ -70,7 +70,7 @@ get_absolute_path() {
 
 install_default_gems() {
   local args=()
-  local default_gems="${HOME}/.default-gems"
+  local default_gems="${ASDF_GEM_DEFAULT_PACKAGES_FILE:=$HOME/.default-gems}"
   local gem="${ASDF_INSTALL_PATH}/bin/gem"
 
   if [ ! -f "$default_gems" ]; then


### PR DESCRIPTION
Similair to the implementations created in https://github.com/asdf-vm/asdf-nodejs/pull/170 and https://github.com/danhper/asdf-python/pull/63; which are already merged. This provides an alternative to https://github.com/asdf-vm/asdf-ruby/pull/114. 