### PR TITLE
Improve `Gemfile` version parsing

### DIFF
--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -6,7 +6,7 @@ get_legacy_version() {
 
   if [ "$basename" == "Gemfile" ]; then
     RUBY_VERSION=$(grep '^\s*ruby' "$current_file" |
-      sed -e 's/[[:space:]]/ /g' -e 's/#.*//' \
+      sed -e 's/[[:space:]]/ /g' -e 's/#.*//' -e 's/[()]//' \
       -e 's/engine:/:engine =>/' -e 's/engine_version:/:engine_version =>/' \
       -e "s/.*:engine *=> *['\"]\([^'\"]*\).*:engine_version *=> *['\"]\([^'\"]*\).*/\2__ENGINE__\1/" \
       -e "s/.*:engine_version *=> *['\"]\([^'\"]*\).*:engine *=> *['\"]\([^'\"]*\).*/\1__ENGINE__\2/" \

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -8,10 +8,11 @@ get_legacy_version() {
     RUBY_VERSION=$(grep '^\s*ruby' "$current_file" |
       sed -e 's/[[:space:]]/ /g' -e 's/#.*//' \
       -e 's/engine:/:engine =>/' -e 's/engine_version:/:engine_version =>/' \
-      -e "s/.*:engine *=> *['\"]\([^'\"]*\).*:engine_version *=> *['\"]\([^'\"]*\).*/\1-\2/" \
-      -e "s/.*:engine_version *=> *['\"]\([^'\"]*\).*:engine *=> *['\"]\([^'\"]*\).*/\2-\1/" \
+      -e "s/.*:engine *=> *['\"]\([^'\"]*\).*:engine_version *=> *['\"]\([^'\"]*\).*/\2__ENGINE__\1/" \
+      -e "s/.*:engine_version *=> *['\"]\([^'\"]*\).*:engine *=> *['\"]\([^'\"]*\).*/\1__ENGINE__\2/" \
       -e "s/ *ruby *['\"]\([^'\"]*\).*/\1/" \
-      -e "/^[^0-9]/d" |
+      -e "/^[^0-9]/d" \
+      -e "s/\(.*\)__ENGINE__\(.*\)/\2-\1/" |
       head -1)
   elif [ "$basename" == ".ruby-version" ]; then
     # Get version from .ruby-version file (filters out 'ruby-' prefix if it exists).


### PR DESCRIPTION
Fixes #214 
Fixes #215 

Tested using this script:

```bash
#!/usr/bin/env bash

set -euo pipefail

function cases() {
	cat <<EOF
2.0.0|ruby '2.0.0'
2.0.0|ruby "2.0.0"
2.0.0|ruby("2.0.0")
2.0.0|ruby "2.0.0" # a comment
2.0.0|     ruby  "2.0.0"       ,:patchlevel         => "200
2.0.0-dev|ruby "2.0.0-dev"
|ruby "~> 2.0.0"
jruby-1.0.0|ruby '2.0.0', engine: 'jruby', engine_version: '1.0.0'
jruby-1.0.0|ruby "2.0.0", engine: "jruby", engine_version: "1.0.0"
jruby-1.0.0|ruby("2.0.0", engine: "jruby", engine_version: "1.0.0")
jruby-1.0.0|ruby "2.0.0", :engine => "jruby", :engine_version => "1.0.0"
jruby-1.0.0|ruby "2.0.0", :engine_version => "1.0.0", :engine => "jruby"
jruby-1.0.0-dev|ruby "2.0.0", :engine => "jruby", :engine_version => "1.0.0-dev"
|ruby "2.0.0", :engine => "jruby", :engine_version => "~> 1.0.0"
EOF
}

function main() {
	printf -- " 🆗 |     expected    |     actual      | case                                                                   |\n"
	printf -- "----+-----------------+-----------------+------------------------------------------------------------------------+\n"

	while read -r line; do
		case="${line//*|/}"

		tmpdir="$(mktemp -d)"
		tmpfile="$tmpdir/Gemfile"

		echo "$case" >"$tmpfile"

		expected="${line//|*/}"
		actual=$(bin/parse-legacy-file "$tmpfile")

		if [[ "$actual" = "$expected" ]]; then
			printf " ✅ | %15s | %15s | %-70s |\n" "$expected" "$actual" "$case"
		else
			printf " ⛔ | %15s | %15s | %-70s |\n" "$expected" "$actual" "$case"
		fi

		rm -rf "$tmpdir"
	done < <(cases)
}

main
```

Test results on `master`:

```
$ ./test
 🆗 |     expected    |     actual      | case                                                                   |
----+-----------------+-----------------+------------------------------------------------------------------------+
 ✅ |           2.0.0 |           2.0.0 | ruby '2.0.0'                                                           |
 ✅ |           2.0.0 |           2.0.0 | ruby "2.0.0"                                                           |
 ⛔ |           2.0.0 |                 | ruby("2.0.0")                                                          |
 ✅ |           2.0.0 |           2.0.0 | ruby "2.0.0" # a comment                                               |
 ✅ |           2.0.0 |           2.0.0 |      ruby  "2.0.0"       ,:patchlevel         => "200                  |
 ✅ |       2.0.0-dev |       2.0.0-dev | ruby "2.0.0-dev"                                                       |
 ✅ |                 |                 | ruby "~> 2.0.0"                                                        |
 ⛔ |     jruby-1.0.0 |                 | ruby '2.0.0', engine: 'jruby', engine_version: '1.0.0'                 |
 ⛔ |     jruby-1.0.0 |                 | ruby "2.0.0", engine: "jruby", engine_version: "1.0.0"                 |
 ⛔ |     jruby-1.0.0 |                 | ruby("2.0.0", engine: "jruby", engine_version: "1.0.0")                |
 ⛔ |     jruby-1.0.0 |                 | ruby "2.0.0", :engine => "jruby", :engine_version => "1.0.0"           |
 ⛔ |     jruby-1.0.0 |                 | ruby "2.0.0", :engine_version => "1.0.0", :engine => "jruby"           |
 ⛔ | jruby-1.0.0-dev |                 | ruby "2.0.0", :engine => "jruby", :engine_version => "1.0.0-dev"       |
 ✅ |                 |                 | ruby "2.0.0", :engine => "jruby", :engine_version => "~> 1.0.0"        |
```

Test results on this branch:

```
$ ./test
 🆗 |     expected    |     actual      | case                                                                   |
----+-----------------+-----------------+------------------------------------------------------------------------+
 ✅ |           2.0.0 |           2.0.0 | ruby '2.0.0'                                                           |
 ✅ |           2.0.0 |           2.0.0 | ruby "2.0.0"                                                           |
 ✅ |           2.0.0 |           2.0.0 | ruby("2.0.0")                                                          |
 ✅ |           2.0.0 |           2.0.0 | ruby "2.0.0" # a comment                                               |
 ✅ |           2.0.0 |           2.0.0 |      ruby  "2.0.0"       ,:patchlevel         => "200                  |
 ✅ |       2.0.0-dev |       2.0.0-dev | ruby "2.0.0-dev"                                                       |
 ✅ |                 |                 | ruby "~> 2.0.0"                                                        |
 ✅ |     jruby-1.0.0 |     jruby-1.0.0 | ruby '2.0.0', engine: 'jruby', engine_version: '1.0.0'                 |
 ✅ |     jruby-1.0.0 |     jruby-1.0.0 | ruby "2.0.0", engine: "jruby", engine_version: "1.0.0"                 |
 ✅ |     jruby-1.0.0 |     jruby-1.0.0 | ruby("2.0.0", engine: "jruby", engine_version: "1.0.0")                |
 ✅ |     jruby-1.0.0 |     jruby-1.0.0 | ruby "2.0.0", :engine => "jruby", :engine_version => "1.0.0"           |
 ✅ |     jruby-1.0.0 |     jruby-1.0.0 | ruby "2.0.0", :engine_version => "1.0.0", :engine => "jruby"           |
 ✅ | jruby-1.0.0-dev | jruby-1.0.0-dev | ruby "2.0.0", :engine => "jruby", :engine_version => "1.0.0-dev"       |
 ✅ |                 |                 | ruby "2.0.0", :engine => "jruby", :engine_version => "~> 1.0.0"        |
```