### PR TITLE
exec-env: only modify PATH if `$install_path` set

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -9,4 +9,6 @@ else
   export RUBYLIB="$ruby_plugin_dir/rubygems-plugin:$RUBYLIB"
 fi
 
-export PATH=$install_path/bin:$PATH
+if [ "${install_path}" ]; then
+    export PATH=$install_path/bin:$PATH
+fi


### PR DESCRIPTION
when using `asdf` with `direnv`, i noticed that path manipulation was
not working for me. example with nodejs:

```bash
igor47@fortress:~ $ asdf current nodejs
nodejs          12.13.1         /home/igor47/.node-version
igor47@fortress:~ $ node --version
v17.7.2
igor47@fortress:~ $ which node
/bin/node
igor47@fortress:~ $ asdf exec node --version
v12.13.1
```

examining my `$PATH`, i see something like:

```
igor47@fortress:~ $ echo $PATH
/home/igor47/.asdf/installs/terraform/0.13.1/bin:/home/igor47/.asdf/installs/direnv/2.21.2/bin:/bin:/home/igor47/.asdf/installs/ruby/2.7.1/bin:/home/igor47/.asdf/installs/nodejs/12.13.1/.npm/bin:/home/igor47/.asdf/installs/nodejs/12.13.1/bin:/home/igor47/.asdf/plugins/nodejs/shims:/home/igor47/.asdf/installs/python/3.8.3/bin:/home/igor47/.asdf/installs/python/2.7.18/bin:<snipped>
```

i notice the strange inclusion of `/bin` in my path, between the paths
for `ruby` and `direnv`. this completely breaks direnv for any plugins
that are loaded before the ruby plugin -- my binaries are now coming
from my local filesystem, and asdf-managed versions are ignored.

looking at ruby's `exec-env` script, which is executed by direnv when
the environment changes, i see that it's attempting to add
`$install_path/bin` to $PATH, but `$install_path` is not set in the
script, nor does it come from the parent environment. in fact, i'm not
sure where `$install_path` would EVER be set.

in this PR, i gate the additional modification of `$PATH`, conditional
on `$install_path` being set, to prevent `/bin` getting into the
`$PATH`. it might also be acceptable here to just get rid of that line,
but i left it in just in case `$install_path` *does* get set *somewhere*
and i'm just  missing it.