### PR TITLE
Don't assume that the `RUBYLIB` environment variable exists

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -3,6 +3,7 @@
 current_script_path=${BASH_SOURCE[0]}
 ruby_plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
+RUBYLIB=${RUBYLIB:-}
 if [ "$RUBYLIB" = "" ]; then
   export RUBYLIB="$ruby_plugin_dir/rubygems-plugin"
 else


### PR DESCRIPTION
When run under asdf-direnv with direnv's `strict_env` set to true, then
this script will run with bash's `nounset` enabled, which will cause
this script to crash in the following way:

    ./exec-env:6: RUBYLIB: unbound variable

(see https://github.com/asdf-community/asdf-direnv/issues/115 for
details)

I know this doesn't affect regular asdf users, but this seems like a
reasonable change to make, I hope you'll accept it!