### PR TITLE
Use `ASDF_INSTALL_PATH` instead of `install_path`

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -9,4 +9,4 @@ else
   export RUBYLIB="$ruby_plugin_dir/rubygems-plugin:$RUBYLIB"
 fi
 
-export PATH=$install_path/bin:$PATH
+export PATH=$ASDF_INSTALL_PATH/bin:$PATH


### PR DESCRIPTION
`ASDF_INSTALL_PATH` is documented here: https://asdf-vm.com/plugins/create.html#environment-variables

`install_path` *does* exist, but we shouldn't rely upon its existence.
It's a local variable of an asdf function that just happens to be
calling this `exec-env` via a `.` (aka: "source") directive:
https://github.com/asdf-vm/asdf/blob/2a538fe63144c3d0710df23738c1f06363b10fa6/lib/utils.bash#L571-L579.
We shouldn't rely on this implementation detail when there's a
documented alternative.