### PR TITLE
fix: Duplicate bin path in PATH due to exec-env setting PATH

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -9,5 +9,3 @@ if [ "$RUBYLIB" = "" ]; then
 else
   export RUBYLIB="$ruby_plugin_dir/rubygems-plugin:$RUBYLIB"
 fi
-
-export PATH=$ASDF_INSTALL_PATH/bin:$PATH


### PR DESCRIPTION
The bin/exec-env command is adding $ASDF_INSTALL_PATH/bin to PATH, but asdf already does this automatically. This causes a [duplicate ruby/bin in PATH when used with the asdf-direnv plugin.](https://github.com/asdf-community/asdf-direnv/issues/148) 