### PR TITLE
Replace ceased travis-ci.org with GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+  push:
+    branches:
+      - 'master'
+    paths-ignore:
+      - "**.md"
+
+jobs:
+  test:
+    needs: [lint]
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Test plugin
+        uses: asdf-vm/actions/plugin-test@v1
+        with:
+          command: ruby -v
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        run: shellcheck bin/* lib/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: c
-script: asdf plugin test ruby . --asdf-plugin-gitref $TRAVIS_BRANCH ruby -v
-before_script:
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export TRUFFLERUBY_RECOMPILE_OPENSSL=false; fi
-  - git clone https://github.com/asdf-vm/asdf.git
-  - . asdf/asdf.sh
-os:
-  - linux
-  - osx

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # asdf-ruby
 
-[![Build Status](https://travis-ci.org/asdf-vm/asdf-ruby.svg?branch=master)](https://travis-ci.org/asdf-vm/asdf-ruby)
+[![Build Status](https://github.com/asdf-vm/asdf-ruby/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/asdf-vm/asdf-ruby/actions/workflows/ci.yml?query=branch%master)
 
 Ruby plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # asdf-ruby
 
-[![Build Status](https://github.com/asdf-vm/asdf-ruby/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/asdf-vm/asdf-ruby/actions/workflows/ci.yml?query=branch%master)
+[![Build Status](https://github.com/asdf-vm/asdf-ruby/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/asdf-vm/asdf-ruby/actions/workflows/ci.yml?query=branch%3Amaster++)
 
 Ruby plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 

--- a/bin/install
+++ b/bin/install
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-# shellcheck source=../lib/utils.sh
+# shellcheck source=/dev/null
 source "$(dirname "$0")/../lib/utils.sh"
 
 install_ruby() {
@@ -114,6 +114,7 @@ install_default_gems() {
       args=()
     fi
 
+    # shellcheck disable=SC2145
     echo -n "Running: gem install $gem_name ${args[@]:-} ... "
 
     if output=$("$gem" install "$gem_name" "${args[@]+"${args[@]}"}" 2>&1); then

--- a/bin/list-all
+++ b/bin/list-all
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-# shellcheck source=../lib/utils.sh
+# shellcheck source=/dev/null
 source "$(dirname "$0")/../lib/utils.sh"
 
 list_versions() {

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 RUBY_BUILD_VERSION="${ASDF_RUBY_BUILD_VERSION:-v20220713}"
 RUBY_BUILD_TAG="$RUBY_BUILD_VERSION"
 
@@ -23,6 +25,7 @@ ensure_ruby_build_installed() {
         current_ruby_build_version="$("$(ruby_build_path)" --version | cut -d ' ' -f2)"
         # If ruby-build version does not start with 'v',
         # add 'v' to beginning of version
+        # shellcheck disable=SC2086
         if [ ${current_ruby_build_version:0:1} != "v" ]; then
           current_ruby_build_version="v$current_ruby_build_version"
         fi
@@ -38,6 +41,7 @@ ensure_ruby_build_installed() {
 download_ruby_build() {
     # Print to stderr so asdf doesn't assume this string is a list of versions
     echoerr "Downloading ruby-build..."
+    # shellcheck disable=SC2155
     local build_dir="$(ruby_build_source_dir)"
 
     # Remove directory in case it still exists from last download
@@ -45,7 +49,7 @@ download_ruby_build() {
 
     # Clone down and checkout the correct ruby-build version
     git clone https://github.com/rbenv/ruby-build.git "$build_dir" >/dev/null 2>&1
-    (cd "$build_dir"; git checkout "$RUBY_BUILD_TAG" >/dev/null 2>&1)
+    (cd "$build_dir" || exit; git checkout "$RUBY_BUILD_TAG" >/dev/null 2>&1)
 
     # Install in the ruby-build dir
     PREFIX="$(ruby_build_dir)" "$build_dir/install.sh"
@@ -55,6 +59,7 @@ download_ruby_build() {
 }
 
 asdf_ruby_plugin_path() {
+    # shellcheck disable=SC2005
     echo "$(dirname "$(dirname "$0")")"
 }
 ruby_build_dir() {


### PR DESCRIPTION
Looks like the current CI is not running. At least I can't see the result link from badges.

https://blog.travis-ci.com/2021-05-07-orgshutdown

So I have replaced to GitHub Actions with https://github.com/asdf-vm/actions/blob/171cc3570019f3a69ba10ae269ab46990936fa9f/README.md instruction except integrating `shfmt`.

* New CI testing with `3.1.2` for now.
* Integrating `shfmt` made [a lot of diff](https://github.com/kachick/asdf-ruby/runs/7450394069?check_suite_focus=true), so I have omitted it.
* Basically disabled `ShellCheck` alerting in current code to keep as-is behavior.
