### PR TITLE
Improve "Version not found" message

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -35,7 +35,7 @@ install_ruby() {
   set -e
 
   if [[ -z "$matching_version" ]]; then
-    errorexit "Version not found"
+    errorexit "Version not found\n\nIf this is a new Ruby version, you may need to update the plugin:\nasdf plugin update ruby"
   fi
 
   # shellcheck disable=SC2086


### PR DESCRIPTION
Previously, if users attempted to install a new version of Ruby, they would just see "Version not found":

```shell
% asdf install ruby 2.7.7
Version not found
```

It may be useful to give a hint to the user that the plugin has to be updated:

```shell
% asdf install ruby 2.7.7
Version not found

If this is a new Ruby version, you may need to run:
asdf plugin update ruby
```