### PR TITLE
docs: update installation to match asdf v0.5.0 command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ruby plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 ## Install
 
 ```
-asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git
+asdf plugin-add ruby https://github.com/asdf-vm/asdf-ruby.git
 ```
 
 Please make sure you have the required [system dependencies](https://github.com/rbenv/ruby-build/wiki#suggested-build-environment) installed before trying to install Ruby. It is also recommended that you [remove other ruby version managers before using asdf-ruby](#troubleshooting)


### PR DESCRIPTION
docs: update installation to match asdf v0.5.0 command

asdf v0.5.0 tells you to manage plugins using the format `asdf plugin-{command} ...` rather than `asdf plugin {command} ...`