### PR TITLE
add list-bin-paths command

### DIFF
--- a/bin/list-bin-paths
+++ b/bin/list-bin-paths
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+gem_version="${ASDF_INSTALL_VERSION%.*}.0"
+echo "bin lib/ruby/gems/$gem_version/bin"


### PR DESCRIPTION
There can be the situation where the binary files of an Gem aren't installed into the common `bin` directory.

This happens when the Gem Specification is lacking the `bindir` setting.