### PR TITLE
fix: default-gems empty line

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -95,7 +95,7 @@ install_default_gems() {
   # Parsing of .default-gems was originally lifted from rbenv-default-gems
   # which is Copyright (c) 2013 Sam Stephenson
   # https://github.com/rbenv/rbenv-default-gems/blob/ead6788/LICENSE
-  while IFS=" " read -r -a line; do
+  while IFS=" " read -r -a line || [ -n "$line" ]; do
 
     # Skip empty lines.
     [ "${#line[@]}" -gt 0 ] || continue


### PR DESCRIPTION
## What

This PR address Issue https://github.com/asdf-vm/asdf-ruby/issues/335. Where a `.default-gems` file without a final empty line, will skip the last gem specified.

The fix is based on [SO answer](https://stackoverflow.com/a/12916758/13783004).
